### PR TITLE
fixed expecting .success property to be present in {wait: true} request

### DIFF
--- a/lib/kraken.js
+++ b/lib/kraken.js
@@ -39,7 +39,8 @@ Kraken.prototype._createResponseHandler = function (cb) {
       return cb(err);
     }
 
-    if (!body.success) {
+    // in case of unsuccessful request with {wait: true}
+    if (body.success === false) {
       return cb(new Error(body.message));
     } else {
       return cb(undefined, body);


### PR DESCRIPTION
this PR fixes requests which use `callback_url` instead of `{wait: true}`.