### PR TITLE
Accept buffers on file prop using request module support

### DIFF
--- a/lib/kraken.js
+++ b/lib/kraken.js
@@ -88,6 +88,8 @@ Kraken.prototype.upload = function (opts, cb) {
 
     if (opts.file instanceof stream.Stream) {
         formData.file = opts.file;
+    } else if (opts.file instanceof Object) {
+        formData.file = opts.file;
     } else {
         formData.file = fs.createReadStream(opts.file);
     }


### PR DESCRIPTION
We need send a image from a bas64 string, but the current kraken module don't support. It works only with file paths and read streams. But the module 'request' used on it, has support for buffer if you send the options with filename and contentType.

The propose solution is only enable to use the kraken API passing a object on the prop file with value buffer and options.

Use case:
```
const Kraken = require('./kraken-node');
const kraken = new Kraken({
    api_key: '<...>',
    api_secret: '<...>'
});

const data = body64.replace(/^data:image\/\w+;base64,/, '');
const buffer = new Buffer(data, 'base64');
const opts = {
    file: {
        value: buffer,
        options: {
            filename: `${Date.now()}.png`,
            contentType: 'image/png'
        }
    },
    wait: true
};

kraken.upload(opts, function(err, data) {
    if (err) {
        console.log('Failed. Error message: %s', err);
    } else {
        console.log('Success. Optimized image URL: %s', data.kraked_url);
    }
});
```

The solution without this is use directly the API: 
```
request.post({
    url: 'https://api.kraken.io/v1/upload',
    json: true,
    strictSSL: false,
    formData: {
        data: JSON.stringify({
            auth: {
                api_key: "<...>",
                api_secret: "<...>"
            },
            wait: true
        }),
        file: {
            value: buffer,
            options: {
                filename: `${Date.now()}.png`,
                contentType: 'image/png'
            }
        }
    }
}, function optionalCallback(err, httpResponse, body) {
  	if (err || !body.success) {
	    console.log('Failed. Error message: %s', err || body);
	} else {
	    console.log('Success. Optimized image URL: %s', body);
	}
});
```

Thank you, and sorry my english. If have more questions please send me.