### PR TITLE
Added Generic stream support with metadata options for upload

### DIFF
--- a/lib/kraken.js
+++ b/lib/kraken.js
@@ -88,6 +88,8 @@ Kraken.prototype.upload = function (opts, cb) {
 
     if (opts.file instanceof stream.Stream) {
         formData.file = opts.file;
+    } else if (opts.file && opts.file.value instanceof stream.Stream) {
+        formData.file = opts.file;
     } else {
         formData.file = fs.createReadStream(opts.file);
     }


### PR DESCRIPTION
it allows us to pass optional meta-data with an 'options' object with style: {value: DATA, options: OPTIONS} as in the request module specs

The use case is for generic stream such as google-storage file stream where file metadata are missing and the upload end with a failure. We can now use the options field to provide the missing metadata.

```javascript
import Kraken from 'kraken'
import Storage from '@google-cloud/storage'

const store = Storage(GCLOUD_CONFIG)
const bucket = store.bucket(GCLOUD_BUCKET)

const kraken = new Kraken({
    api_key: 'your-api-key',
    api_secret: 'your-api-secret'
})

let file = bucket.file('my-file-path.jpg')
const {size, contentType} = file.metadata

let opts = {
  file: {
    value: file.createReadStream(),
    options: {
      filename: file.name,
      contentType,
      knownLength: size
    }
  },
  wait: true
}

kraken.upload(opts, function (err, data) {
    if (err) {
        console.log('Failed. Error message: %s', err);
    } else {
        console.log('Success. Optimized image URL: %s', data.kraked_url);
    }
})

```