### PR TITLE
Changing requestb.in link -> requestbin.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ With the `wait` option turned on for every request to the API, the connection wi
 
 With the Callback URL the HTTPS connection will be terminated immediately and a unique `id` will be returned in the response body. After the optimization is over Kraken will POST a message to the `callback_url` specified in your request. The ID in the response will reflect the ID in the results posted to your Callback URL.
 
-We recommend [requestb.in](http://requestb.in) as an easy way to capture optimization results for initial testing.
+We recommend [RequestBin.com](http://requestbin.com) as an easy way to capture optimization results for initial testing.
 
 **Request:**
 


### PR DESCRIPTION
requestb.in is no longer operational. Changing to requestbin.com (comparable free request bin service)