### PR TITLE
Update Kraken.io API README with WebP, PDF Compression, GCS Integration, and Node.js 22 Support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 20.x]
+        node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 20.x]
-        
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 20.x, 22.x]
+
     env:
       KRAKEN_API_KEY: ${{ secrets.KRAKEN_API_KEY }}
       KRAKEN_API_SECRET: ${{ secrets.KRAKEN_API_SECRET }}


### PR DESCRIPTION
This update enhances the Kraken.io API README by removing the deprecated webp: true flag, updating WebP compression usage to align with standard requests, and adding documentation for the newly introduced PDF compression and Google Cloud Storage (GCS) integration. The GCS section includes detailed setup instructions, mandatory and optional parameters, and an example API request. Additionally, Node.js 22 is now officially supported,